### PR TITLE
break out watch of pods and namespaces into two separate config variables

### DIFF
--- a/test/plugin/test_filter_kubernetes_metadata.rb
+++ b/test/plugin/test_filter_kubernetes_metadata.rb
@@ -48,7 +48,8 @@ class KubernetesMetadataFilterTest < Test::Unit::TestCase
       VCR.use_cassette('valid_kubernetes_api_server') do
         d = create_driver('
           kubernetes_url https://localhost:8443
-          watch false
+          watch_pods false
+          watch_namespaces false
         ')
         assert_equal('https://localhost:8443', d.instance.kubernetes_url)
         assert_equal(1000, d.instance.cache_size)


### PR DESCRIPTION
`watch` currently enables both watching pod labels and namespace labels.

We have a few namespace label changes we want to capture in our log messages. We have a large number of pods and don't want to bear unnecessary additional strain on the API-servers by watching every pod. This will let us break out and just watch namespaces without having to watch pods.

the old `watch` config variable is still supported. If it's set, it overrides the values of both `watch_namespaces` and `watch_pods`.